### PR TITLE
Support to Build another CPU target in macOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 example
 example.o
-murmur3.o
+murmur3*.o
 test.o
 tests
-libmurmur3.a
+libmurmur3*.a

--- a/makefile
+++ b/makefile
@@ -16,11 +16,13 @@ static: murmur3.c murmur3.h
 	$(CC) -fPIC -O3 -c murmur3.c
 	$(AR) rcs libmurmur3.a murmur3.o
 
-# Create macOS Architecture Specific Binary 
-# It can be arm64-apple-macos11 or x86_64-apple-macos10.12
+# Create macOS Architecture Specific Binaries 
 static_macos: murmur3.c murmur3.h
-	$(CC) -fPIC -O3 -c murmur3.c -target $(TARGET) -o murmur3.o
-	$(AR) rcs libmurmur3.a murmur3.o
-
+	$(CC) -fPIC -O3 -c murmur3.c -target x86_64-apple-macos10.12 -o murmur3-x86_64.o
+	$(CC) -fPIC -O3 -c murmur3.c -target arm64-apple-macos11 -o murmur3-arm64.o
+	$(AR) rcs libmurmur3-x86_64.a murmur3-x86_64.o
+	$(AR) rcs libmurmur3-arm64.a murmur3-arm64.o
+	lipo -create -output libmurmur3.a libmurmur3-x86_64.a libmurmur3-arm64.a
+	
 clean:
 	rm -rf example *.o *.so *.a

--- a/makefile
+++ b/makefile
@@ -16,5 +16,11 @@ static: murmur3.c murmur3.h
 	$(CC) -fPIC -O3 -c murmur3.c
 	$(AR) rcs libmurmur3.a murmur3.o
 
+# Create macOS Architecture Specific Binary 
+# It can be arm64-apple-macos11 or x86_64-apple-macos10.12
+static_macos: murmur3.c murmur3.h
+	$(CC) -fPIC -O3 -c murmur3.c -target $(TARGET) -o murmur3.o
+	$(AR) rcs libmurmur3.a murmur3.o
+
 clean:
 	rm -rf example *.o *.so *.a


### PR DESCRIPTION
This Push Request makes base step for resolving `emcache`'s M1 Build [Issue(#67)](https://github.com/emcache/emcache/issues/67).
This commit can makes build arm64 binary on x86_64, or build x86_64 binary on arm64 devices.

When this PR merged, I'll create another PR for emcache to resolve issue. Thanks. :)